### PR TITLE
Actualizando etiquetas del post MarkDown

### DIFF
--- a/_posts/2024-2-29-MarkDown.md
+++ b/_posts/2024-2-29-MarkDown.md
@@ -2,7 +2,7 @@
 layout: post
 title: Qué es MarkDown y por qué deberías usarlo
 category: programación
-tags: [markdown, escritura, web]
+tags: [markdown, lenguajes-de-marcado, web]
 author: Ulises Milani
 excerpt: Aprende a usar MarkDown, el lenguaje de marcado que te permite crear documentos HTML con un formato sencillo y legible, usando sólo texto plano.
 ---

--- a/_posts/2024-2-29-MarkDown.md
+++ b/_posts/2024-2-29-MarkDown.md
@@ -2,7 +2,7 @@
 layout: post
 title: Qué es MarkDown y por qué deberías usarlo
 category: programación
-tags: [MarkDown, escritura, web]
+tags: [markdown, escritura, web]
 author: Ulises Milani
 excerpt: Aprende a usar MarkDown, el lenguaje de marcado que te permite crear documentos HTML con un formato sencillo y legible, usando sólo texto plano.
 ---

--- a/tags/lenguajes-de-marcado.md
+++ b/tags/lenguajes-de-marcado.md
@@ -1,0 +1,9 @@
+---
+layout: page
+title: Lenguajes de marcado
+permalink: /tag/lenguajes-de-marcado
+---
+
+Contenido para aprender, practicar y mejorar tus habilidades en lenguajes de marcado.
+
+{% include tag-posts.html tag_name='lenguajes-de-marcado' %}

--- a/tags/markdown.md
+++ b/tags/markdown.md
@@ -1,0 +1,9 @@
+---
+layout: page
+title: MarkDown
+permalink: /tag/markdown
+---
+
+Contenido para aprender, practicar y mejorar tus habilidades en MarkDown.
+
+{% include tag-posts.html tag_name='markdown' %}

--- a/tags/web.md
+++ b/tags/web.md
@@ -1,0 +1,9 @@
+---
+layout: page
+title: Web
+permalink: /tag/web
+---
+
+Contenido para aprender, practicar y mejorar tus habilidades en desarrollo Web.
+
+{% include tag-posts.html tag_name='web' %}


### PR DESCRIPTION
Problema:

Cuando vamos al post:

"Qué es MarkDown y por qué deberías usarlo"

vemos las etiquetas:

- MarkDown
- escritura
- web

Pero cuando hacemos clic a alguna de esas etiquetas aparece un 404.

Mejoras:

1. Incluí dentro de la carpeta "tags" los ficheros markdown, lenguajes-de-marcado y web para solucionar el 404.
2. Convertí a minúsculas las etiquetas MarkDown, escritura y web.
3. No tengo claro si las etiquetas todas van en minúsculas, o en mayúsculas, o sin acentos, ya que vi una URL incluso con acento: https://programacion-accesible.github.io/tag/programaci%C3%B3n-accesible-comunidad
4. Remplacé la etiqueta "escritura" por la etiqueta "lenguajes-de-marcado".
5. No tengo claro si se usa camelCase, PascalCase, Kebab-case, en partes específicas del proyecto, pero hice mi mayor esfuerzo mirando que habían hecho otros y en eso me basé.

Quedo atento a sus comentarios 👋